### PR TITLE
Add error rate tests with pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -ra
+# run tests only from the tests directory
+testpaths = tests

--- a/tests/test_error_rate.py
+++ b/tests/test_error_rate.py
@@ -1,0 +1,18 @@
+import numpy as np
+from sklearn.metrics import mean_squared_error
+
+
+def test_error_rate_per_label():
+    true_labels = np.array([120, 1100, 1500, 120, 1100, 1500, 120, 1100, 1500])
+    predicted_labels = np.array([110, 1005, 1450, 110, 1005, 1450, 100, 1005, 1450])
+    unique_labels = np.unique(true_labels)
+    mse_per_label = {
+        label: mean_squared_error(
+            true_labels[true_labels == label],
+            predicted_labels[true_labels == label],
+        )
+        for label in unique_labels
+    }
+    expected = {120: 200.0, 1100: 9025.0, 1500: 2500.0}
+    for label, expected_val in expected.items():
+        assert np.isclose(mse_per_label[label], expected_val)


### PR DESCRIPTION
## Summary
- add per-label MSE test under `tests/`
- configure pytest to only run the `tests` directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452c65fb188320ab046f9982695cc9